### PR TITLE
Fix child 'key' prop' error seen using React v16

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-components-markdown",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "lib/index.js",
   "scripts": {

--- a/src/MarkdownIt.js
+++ b/src/MarkdownIt.js
@@ -11,8 +11,8 @@ export const markdownIt = ({ mdAndComps, wrap, styles }) => (
   <div>
     {
       mdAndComps
-      .map(({ md, component, componentKey }) => ([
-        md && <MarkdownPart styles={styles}>{md}</MarkdownPart>,
+      .map(({ md, component, componentKey }, index) => ([
+        md && <MarkdownPart key={`md-${index}`} styles={styles}>{md}</MarkdownPart>,
         wrap({ component, componentKey }),
       ]))
     }
@@ -27,8 +27,15 @@ export const markdownItHOC = compose(
   mapPropsOnChange(
     ['anchorOffset'],
     ({ anchorOffset }) => ({
-      wrap: ({ component, componentKey }) => (
-        [
+      wrap: ({ component, componentKey }) => {
+        let newComponent;
+        if (component) {
+          newComponent = {
+            ...component,
+            key: `component-${componentKey ? `${componentKey}-` : ''}key`,
+          };
+        }
+        return ([
           <a
             style={{
               display: 'block',
@@ -37,10 +44,11 @@ export const markdownItHOC = compose(
               visibility: 'hidden',
             }}
             name={componentKey}
+            key={`anchor-${componentKey ? `${componentKey}-` : ''}key`}
           />,
-          component,
-        ]
-      ),
+          newComponent,
+        ]);
+      },
     })
   ),
   mapPropsOnChange(


### PR DESCRIPTION
I noticed that there are missing key warnings seen when using current versions of react (specifically, 16):
`Warning: Each child in an array or iterator should have a unique "key" prop.`

I've added keys to the necessary element; made sure the tests pass and examples work properly.